### PR TITLE
Fix missing NOTICE in releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.4",
   "description": "A simple library to display tooltips for Final Fantasy XIV data",
   "main": "dist/vue-xivtooltips.min.js",
-  "files": ["dist"],
+  "files": [
+    "dist",
+    "NOTICE"
+  ],
   "author": "Oowazu Nonowazu <oowazu.nonowazu@gmail.com>",
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
This is actually really dumb. NPM explicitly includes NOTICE files, but for some reason Yarn doesn't so it needs to be added to the publish config. No change required in rollup since it's not a distributable file.