### PR TITLE
Add DoH+DoL support

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,7 @@
 Copyright 2020 Oowazu Nonowazu <oowazu.nonowazu@gmail.com>
 Copyright 2020 SaltedLevity "Levi" <saltedlevity@gmail.com>
 Copyright 2020 ArcaneDisgea "Dis" <arc@arcanedisgea.com>
+Copyright 2020 Ay'yaruq Dotharl <acchan.ff14@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/example/demo.html
+++ b/example/demo.html
@@ -49,11 +49,17 @@
             <hr />
 
             <h1>Standalone Icon (with lookup)</h1>
-            <ActionFetch :id="16550"></ActionFetch>
+            <ActionFetch :id="16470"></ActionFetch>
             <hr />
 
             <h1>Embedded (with lookup)</h1>
             <ActionFetch :id="63" embedded></ActionFetch>
+            <hr />
+
+            <h1>Crafting and Gatherering Actions (with lookup)</h1>
+            <ActionFetch :id="19009" embedded></ActionFetch>
+            <br />
+            <ActionFetch :id="4084" embedded></ActionFetch>
         </div>
         <script src="https://unpkg.com/vue@2.6.11/dist/vue.js"></script>
         <script src="https://unpkg.com/vuex@3.0.1/dist/vuex.js"></script>

--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -229,7 +229,7 @@ export default {
                         {{ costType }} Cost
                     </div>
                     <div class="xivtooltip-c xivtooltip-value">
-                        {{ PrimaryCostValue * 100 }}
+                        {{ PrimaryCostType === 3 ? PrimaryCostValue * 100 : PrimaryCostValue }}
                     </div>
                 </div>
             </div>

--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -139,6 +139,7 @@ export default {
     ActionCategory: {
       type: Object,
       default: () => ({
+        ID: 0,
         Name_en: '',
         Name_fr: '',
         Name_de: '',
@@ -151,6 +152,7 @@ export default {
     ClassJobCategory: {
       type: Object,
       default: () => ({
+        ID: 0,
         Name_en: '',
         Name_fr: '',
         Name_de: '',

--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -5,6 +5,8 @@ const resourceMapping = {
   8: 'CP',
 }
 
+const actionCategoryNonCombat = [ 6, 7 ]
+
 export default {
   name: 'ActionTooltip',
   filters: {
@@ -172,10 +174,11 @@ export default {
     name () { return this[`Name_${this.lang}`] },
     icon () { return `https://xivapi.com${this.Icon}` },
     actionCategory () { return this.ActionCategory ? this.ActionCategory[`Name_${this.lang}`] : '' },
-    actionNonCombatant () { return [6, 7].includes(this.ActionCategory.ID) },
+    actionNonCombatant () { return actionCategoryNonCombat.includes(this.ActionCategory.ID) },
     description () { return this[`Description_${this.lang}`].replace(/\n\n/g, '<br/>') },
     classJobCategory () { return this.ClassJobCategory ? this.ClassJobCategory[`Name_${this.lang}`] : '' },
     costType () { return resourceMapping[this.PrimaryCostType] },
+    costValue () { return this.PrimaryCostType === 3 ? this.PrimaryCostValue * 100 : this.PrimaryCostValue }
     costShouldDisplay () { return Object.keys(resourceMapping).map(Number).includes(this.PrimaryCostType) && this.PrimaryCostValue > 0 },
     range () { return this.Range === -1 ? 3 : this.Range },
   },
@@ -241,7 +244,7 @@ export default {
                         {{ costType }} Cost
                     </div>
                     <div class="xivtooltip-c xivtooltip-value">
-                        {{ PrimaryCostType === 3 ? PrimaryCostValue * 100 : PrimaryCostValue }}
+                        {{ costValue }}
                     </div>
                 </div>
             </div>

--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -1,5 +1,5 @@
 <script>
-export const resourceMapping = {
+const resourceMapping = {
   3: 'MP',
   7: 'GP',
   8: 'CP',
@@ -170,6 +170,7 @@ export default {
     name () { return this[`Name_${this.lang}`] },
     icon () { return `https://xivapi.com${this.Icon}` },
     actionCategory () { return this.ActionCategory ? this.ActionCategory[`Name_${this.lang}`] : '' },
+    actionNonCombatant () { return [6, 7].includes(this.ActionCategory.ID) },
     description () { return this[`Description_${this.lang}`].replace(/\n\n/g, '<br/>') },
     classJobCategory () { return this.ClassJobCategory ? this.ClassJobCategory[`Name_${this.lang}`] : '' },
     costType () { return resourceMapping[this.PrimaryCostType] },
@@ -204,7 +205,10 @@ export default {
                 </div>
             </div>
             <div class="xivtooltip-mid">
-                <div class="xivtooltip-cooldown">
+                <div
+                    class="xivtooltip-cooldown"
+                    :style="[actionNonCombatant ? { 'visibility': 'hidden' } : {}]"
+                >
                     <div class="xivtooltip-c xivtooltip-text">
                         Cast
                     </div>
@@ -213,7 +217,10 @@ export default {
                         <span v-else>Instant</span>
                     </div>
                 </div>
-                <div class="xivtooltip-cooldown">
+                <div
+                    class="xivtooltip-cooldown"
+                    :style="[Recast100ms === 0 ? { 'visibility': 'hidden' } : {}]"
+                >
                     <div class="xivtooltip-c xivtooltip-text">
                         Recast
                     </div>

--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -5,6 +5,9 @@ const resourceMapping = {
   8: 'CP',
 }
 
+/**
+ * Categories 6 and 7 are for DoL and DoH abilities respectively.
+ */
 const actionCategoryNonCombat = [ 6, 7 ]
 
 export default {

--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -178,7 +178,7 @@ export default {
     description () { return this[`Description_${this.lang}`].replace(/\n\n/g, '<br/>') },
     classJobCategory () { return this.ClassJobCategory ? this.ClassJobCategory[`Name_${this.lang}`] : '' },
     costType () { return resourceMapping[this.PrimaryCostType] },
-    costValue () { return this.PrimaryCostType === 3 ? this.PrimaryCostValue * 100 : this.PrimaryCostValue }
+    costValue () { return this.PrimaryCostType === 3 ? this.PrimaryCostValue * 100 : this.PrimaryCostValue },
     costShouldDisplay () { return Object.keys(resourceMapping).map(Number).includes(this.PrimaryCostType) && this.PrimaryCostValue > 0 },
     range () { return this.Range === -1 ? 3 : this.Range },
   },

--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -1,4 +1,10 @@
 <script>
+export const resourceMapping = {
+  3: 'MP',
+  7: 'GP',
+  8: 'CP',
+}
+
 export default {
   name: 'ActionTooltip',
   filters: {
@@ -121,7 +127,7 @@ export default {
       default: 0,
     },
     /**
-     * The MP cost of the action
+     * The cost of the action
      */
     PrimaryCostValue: {
       type: Number,
@@ -166,6 +172,7 @@ export default {
     actionCategory () { return this.ActionCategory ? this.ActionCategory[`Name_${this.lang}`] : '' },
     description () { return this[`Description_${this.lang}`].replace(/\n\n/g, '<br/>') },
     classJobCategory () { return this.ClassJobCategory ? this.ClassJobCategory[`Name_${this.lang}`] : '' },
+    costType () { return resourceMapping[this.PrimaryCostType] },
     range () { return this.Range === -1 ? 3 : this.Range },
   },
 }
@@ -218,7 +225,7 @@ export default {
                     :style="[(PrimaryCostValue === 0 || PrimaryCostType !== 3) ? { 'visibility': 'hidden' } : {}]"
                 >
                     <div class="xivtooltip-c xivtooltip-text">
-                        MP Cost
+                        {{ costType }} Cost
                     </div>
                     <div class="xivtooltip-c xivtooltip-value">
                         {{ PrimaryCostValue * 100 }}

--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -173,6 +173,7 @@ export default {
     description () { return this[`Description_${this.lang}`].replace(/\n\n/g, '<br/>') },
     classJobCategory () { return this.ClassJobCategory ? this.ClassJobCategory[`Name_${this.lang}`] : '' },
     costType () { return resourceMapping[this.PrimaryCostType] },
+    costShouldDisplay () { return Object.keys(resourceMapping).map(Number).includes(this.PrimaryCostType) && this.PrimaryCostValue > 0 },
     range () { return this.Range === -1 ? 3 : this.Range },
   },
 }
@@ -222,7 +223,7 @@ export default {
                 </div>
                 <div 
                     class="xivtooltip-cooldown xivtooltip-cost" 
-                    :style="[(PrimaryCostValue === 0 || PrimaryCostType !== 3) ? { 'visibility': 'hidden' } : {}]"
+                    :style="[costShouldDisplay ? {} : { 'visibility': 'hidden' }]"
                 >
                     <div class="xivtooltip-c xivtooltip-text">
                         {{ costType }} Cost

--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -194,7 +194,10 @@ export default {
                     <div class="xivtooltip-classification xivtooltip-text">
                         {{ actionCategory }}
                     </div>
-                    <div class="xivtooltip-area-of-effect">
+                    <div
+                        class="xivtooltip-area-of-effect"
+                        :style="[actionNonCombatant ? { 'visibility': 'hidden' } : {}]"
+                    >
                         <div class="xivtooltip-aoe xivtooltip-text">
                             Range <span class="xivtooltip-value">{{ range }}y</span>
                         </div>


### PR DESCRIPTION
This mostly addresses cost types, but happens to improve examples and add proper support for crafters (and stinky gatherers like Hiems).

![image](https://user-images.githubusercontent.com/28627120/99493961-4f8e8080-29c4-11eb-909c-d88799073ee4.png)

I'll note that for crafters specifically, this only works for *Actions*, not *CraftActions* which are a different index in xivapi with completely different structure. The weird thing with DoH is that there's an Action for all 8 crafters, but identical icons etc, rather than co-opting the role icon system like combat jobs do. CraftActions are also job specific, but are unique in that their icons change per job, while crafter skills in the Action index have the same icon.