### PR TITLE
Update package and copyright for XIVAPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,6 @@ jobs:
       run: yarn build
 
     - name: Upload
-      run: yarn publish
+      run: yarn publish --access public
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ dist/
 # Storybook build outputs
 .out
 .storybook-out
+storybook-static
 
 # vuepress build output
 .vuepress/dist

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,4 @@
+Copyright 2021 XIVAPI
 Copyright 2020 Oowazu Nonowazu <oowazu.nonowazu@gmail.com>
 Copyright 2020 SaltedLevity "Levi" <saltedlevity@gmail.com>
 Copyright 2020 ArcaneDisgea "Dis" <arc@arcanedisgea.com>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,21 @@
 {
-  "name": "vue-xivtooltips",
+  "name": "@xivapi/vue-xivtooltips",
   "version": "0.1.8",
   "description": "A simple library to display tooltips for Final Fantasy XIV data",
   "author": "Oowazu Nonowazu <oowazu.nonowazu@gmail.com>",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/xivapi/vue-xivtooltips",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/xivapi/vue-xivtooltips.git"
+  },
+  "bugs": {
+    "https://github.com/xivapi/vue-xivtooltips/issues"
+  },
+  "keywords": [
+    "ffxiv",
+    "xivapi"
+  ]
   "scripts": {
     "build": "vue-cli-service build --target lib --formats umd-min --name VueXIVTooltips --filename vue-xivtooltips src/index.js",
     "lint": "eslint --ext .js --ext .vue src",
@@ -44,10 +57,5 @@
     "vue-template-compiler": "^2.6.11",
     "vuex": "^3.3.0"
   },
-  "peerDependencies": {},
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/nonowazu/vue-xivtooltips"
-  }
+  "peerDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/xivapi/vue-xivtooltips.git"
   },
   "bugs": {
-    "https://github.com/xivapi/vue-xivtooltips/issues"
+    "url": "https://github.com/xivapi/vue-xivtooltips/issues"
   },
   "keywords": [
     "ffxiv",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "keywords": [
     "ffxiv",
     "xivapi"
-  ]
+  ],
   "scripts": {
     "build": "vue-cli-service build --target lib --formats umd-min --name VueXIVTooltips --filename vue-xivtooltips src/index.js",
     "lint": "eslint --ext .js --ext .vue src",


### PR DESCRIPTION
What it says on the tin. I'm leaving the author as Nono but we can add specific maintainers if people want. For any contributors that are also members of xivapi, feel free to fold yourself into the xivapi copyright if you don't want your name there. Leaving this PR up for a few days for people to confirm, then I'll merge and re-publish the latest (0.1.8) release to npm with the xivapi scope.